### PR TITLE
Get rid of extra "with" in text

### DIFF
--- a/components/bobaMaker.js
+++ b/components/bobaMaker.js
@@ -10,7 +10,8 @@ class BobaMaker extends HTMLElement {
           <label>size:
             <select name="size" id="size-select">${this.createOptions(
               options.size,
-              lookupTables.size
+              lookupTables.size,
+              'size'
             )}</select>
           </label>
 
@@ -25,14 +26,16 @@ class BobaMaker extends HTMLElement {
           <label>topping1:
             <select name="topping1" id="topping1-select">${this.createOptions(
               options.toppings,
-              lookupTables.toppings
+              lookupTables.toppings,
+              'toppings'
             )}</select>
           </label>
 
           <label>topping2:
             <select name="topping2" id="topping2-select">${this.createOptions(
               options.toppings,
-              lookupTables.toppings
+              lookupTables.toppings,
+              'toppings'
             )}</select>
           </label>
 
@@ -43,6 +46,7 @@ class BobaMaker extends HTMLElement {
     `;
   }
 
+  // Creates all the options for a particular label
   createOptions(options, lookupTable, type) {
     const optionNodes = options.map((option) => {
       // Look up the name which will be used as display text
@@ -53,9 +57,21 @@ class BobaMaker extends HTMLElement {
         displayText = displayText.split(' milk')[0];
       }
 
-      return `<option value="${option}">${displayText}</option>`;
+      // Return a single option component for each
+      return this.createSingleOption(option, displayText)
     });
+
+    // If it's a topping, add a none option to it
+    if (type === 'toppings') {
+      optionNodes.push(this.createSingleOption('none', 'none'))
+    }
+
     return optionNodes.join('\n');
+  }
+
+  // Creates a single option element with given text
+  createSingleOption(option, displayText) {
+    return `<option value="${option}">${displayText}</option>`;
   }
 }
 window.customElements.define('boba-maker', BobaMaker);

--- a/components/totalCost.js
+++ b/components/totalCost.js
@@ -11,7 +11,7 @@ class TotalCost extends HTMLElement {
     <br>
     <span id="total-num-bobas">${numBobas}</span>
     <br>
-    ${size} ${flavor} bobas with ${this.formatToppings(topping1, topping2)} 
+    ${size} ${flavor} bobas ${this.formatToppings(topping1, topping2)} 
   </h2>
 </div>`;
   }
@@ -28,15 +28,15 @@ class TotalCost extends HTMLElement {
       // Scenario 1: has 2 toppings
       case 2: {
         // Scenario 1a: both are same
-        if (toppings[0] === toppings[1]) return ` with extra ${toppings[0]}`;
+        if (toppings[0] === toppings[1]) return `with extra ${toppings[0]}`;
 
         // Scenario 1b: toppings are different
-        return ` with ${toppings[0]} and ${toppings[1]}`;
+        return `with ${toppings[0]} and ${toppings[1]}`;
       }
 
       // Scenario 2: has one topping
       case 1:
-        return ` with ${toppings[0]}`;
+        return `with ${toppings[0]}`;
 
       // Scenario 3: no toppings
       default:


### PR DESCRIPTION
The site currently has an extra "with" at the end regardless of whether or not there are toppings. This pull request gets rid of the second "with"

Example:
![image](https://user-images.githubusercontent.com/57082175/131264028-adb94d1a-5f2d-4ba1-b45b-897446133615.png)
